### PR TITLE
[Fix bosh release --final] Putting folder name in separate parameter

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -2,5 +2,6 @@
 blobstore:
   provider: s3
   options:
-    bucket_name: sf-boshrelease/service-fabrik-release-blobs
+    bucket_name: sf-boshrelease
+    folder: service-fabrik-release-blobs
 final_name: service-fabrik


### PR DESCRIPTION
This PR includes fix for issue: https://github.com/SAP/service-fabrik-boshrelease/issues/6
Blobstore error: Failed to create object, S3 response error code NoSuchKey: The specified key does not exist.

During final release call we were getting error.
```shell
Building packages
-----------------
Building golang...
  Using final version '95c358c1eeabe9495e089de333e0c91eee2fef0c'
  Uploading final version '95c358c1eeabe9495e089de333e0c91eee2fef0c'...
  Uploaded, blobstore id '5924ebab-6dec-411b-86c5-8491e94064fc'

Building bosh-helpers...
  Using final version 'e1bbff85fa1e4b1d51887ba6ecff6949ca92e8f6'
  Uploading final version 'e1bbff85fa1e4b1d51887ba6ecff6949ca92e8f6'...
  Uploaded, blobstore id 'ad205f16-f98a-4045-a609-74e9b341c3a9'

Building docker...
  Using final version '45062aefa4be8e9f0a2af53e5591e04be5a8db0b'
  Uploading final version '45062aefa4be8e9f0a2af53e5591e04be5a8db0b'...
  Uploaded, blobstore id 'f932657e-3a77-414d-b90d-fe2c2a42f138'

Building service-fabrik-broker...
  No artifact found for service-fabrik-broker
  Generating...
  Pre-packaging...
  Generated version 'aec6a7837e3d7b2995506145cbeada2c4134ca8f'
  Uploading final version 'aec6a7837e3d7b2995506145cbeada2c4134ca8f'...
Blobstore error: Failed to create object, S3 response error code NoSuchKey: The specified key does not exist.
```