### PR TITLE
Added Travis validations for service-fabrik boshrelease

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+install:
+        - "./scripts/update"
+        - "gem install bosh_cli --no-ri --no-rdoc"
+script:
+        - "bosh create release --force --name service-fabrik"


### PR DESCRIPTION
Currently there are no validations in place for code contributions on service-fabrik-boshrelease.

This adds a .travis.yml file for validating code by creating a dev bosh release and attaching the run status on the PR page