### PR TITLE
Closes-Bug: issues: #9

### DIFF
--- a/jobs/service-fabrik-broker/templates/config/circuit-breaker-config.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/circuit-breaker-config.yml.erb
@@ -13,12 +13,10 @@ http:
   statistical_window_length: 120000 #ms the metrics are caclucated for, after this the metrics are reset.
   statistical_window_number_of_buckets: 10 #statistical window length is sliced into this configured number of buckets
   apis:
-    "<%= p('broker.bootstrap_bosh_director.url') %>":
-      name: "Boot Strap Bosh Director"
-    "<%= p('broker.director.url') %>":
-      name: "Bosh Director"
+    <% p('broker.directors').each do |director| %>
+    "<%= director['url'] %>":
+    name: "<%= director['name'] %>"
+    <% end %>
     "<%= p('broker.cf.url') %>":
       name: "Cloud Controller"
-    "<%= p('broker.quota.serviceDomain')%>":
-      name: "Qutoa Management APIs"
 <% end %>

--- a/jobs/service-fabrik-scheduler/templates/config/circuit-breaker-config.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/circuit-breaker-config.yml.erb
@@ -13,12 +13,10 @@ http:
   statistical_window_length: 120000 #ms the metrics are caclucated for, after this the metrics are reset.
   statistical_window_number_of_buckets: 10 #statistical window length is sliced into this configured number of buckets
   apis:
-    "<%= p('broker.bootstrap_bosh_director.url') %>":
-      name: "Boot Strap Bosh Director"
-    "<%= p('broker.director.url') %>":
-      name: "Bosh Director"
+    <% p('broker.directors').each do |director| %>
+    "<%= director['url'] %>":
+    name: "<%= director['name'] %>"
+    <% end %>
     "<%= p('broker.cf.url') %>":
       name: "Cloud Controller"
-    "<%= p('broker.quota.serviceDomain')%>":
-      name: "Qutoa Management APIs"
 <% end %>

--- a/templates/properties.yml
+++ b/templates/properties.yml
@@ -219,7 +219,7 @@ meta:
       #####################
       #bootstrap_bosh_director settings
       directors:
-      - url: https://192.168.50.3:25555
+      - url: https://192.168.50.4:25555
         username: admin
         password: admin
         primary: false


### PR DESCRIPTION
Description: This fix incorporate changes to circuit breaker config for
multiple bosh

With multiple bosh now we can have more than one directors. The
configuration files instead of having a static configuration now needs
to iterate over the complete array and subsequently add information on
all the directors.

Another change has been made into templates/properties.yml. Since this
properties file is specific to bosh-lite we should have only one single
bosh director.