### PR TITLE
Closes-Bug: issues: Swarm process start is failing

### DIFF
--- a/jobs/swarm_manager/templates/bin/swarm_manager_ctl
+++ b/jobs/swarm_manager/templates/bin/swarm_manager_ctl
@@ -16,7 +16,9 @@ case $1 in
     if [ ! -L /etc/rsyslog.d/45-swarm_manager_forwarding.conf ]; then
         ln -s /var/vcap/jobs/swarm_manager/config/syslog_forwarding.conf /etc/rsyslog.d/45-swarm_manager_forwarding.conf
     fi
+    set +e
     /usr/sbin/service rsyslog restart
+    set -e
 
     # Start Swarm Manager daemon
     exec chpst -u vcap:vcap /var/vcap/packages/swarm/bin/swarm \


### PR DESCRIPTION
During the startup of swarm process we restart the rsyslog, some times
rsyslogs start return non zero value which does not effect functionality of the
swarm process but checking its return value causes landscape deployment to fail.
Hence ignoring the rsyslog restart value.