### PR TITLE
Feature/docker17 upgrade

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -39,3 +39,7 @@ node/node-v6.9.1-linux-x64.tar.xz:
   object_id: e79323b1-66d8-42a6-aba3-df4525ce82cd
   sha: 84b0b6fde43a4d892186119ba6b9f1db3c2c6129
   size: 9351072
+docker/docker-17.06.1.tgz:
+  object_id: 128671d4-33ef-4cad-8239-0ae39d38f55d
+  sha: 01c73e6548e588e6d5bdc3dea45bb90239516e4b
+  size: 29699281

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -22,10 +22,10 @@ docker/autoconf-2.69.tar.gz:
   size: 1927468
   object_id: 83391b7e-d4bf-4052-92bb-e708f33e25c6
   sha: 562471cbcb0dd0fa42a76665acf0dbb68479b78a
-docker/docker-1.12.3.tgz:
-  size: 28891346
-  object_id: 8a0c3c93-e009-4777-9292-8cb8c4e0e73c
-  sha: a3bb88649bcc47775c29dab7d95709f4dda04d0e
+docker/docker-17.06.1.tgz:
+  size: 29699281
+  object_id: 128671d4-33ef-4cad-8239-0ae39d38f55d
+  sha: 01c73e6548e588e6d5bdc3dea45bb90239516e4b
 golang/go1.6.2.linux-amd64.tar.gz:
   size: 84840658
   object_id: abc1be7b-ce69-4442-a841-cfc0a88109e4
@@ -38,7 +38,3 @@ node/node-v6.9.1-linux-x64.tar.xz:
   size: 9351072
   object_id: e79323b1-66d8-42a6-aba3-df4525ce82cd
   sha: 84b0b6fde43a4d892186119ba6b9f1db3c2c6129
-docker/docker-17.06.1.tgz:
-  object_id: 128671d4-33ef-4cad-8239-0ae39d38f55d
-  sha: 01c73e6548e588e6d5bdc3dea45bb90239516e4b
-  size: 29699281

--- a/jobs/docker/templates/bin/docker_ctl.erb
+++ b/jobs/docker/templates/bin/docker_ctl.erb
@@ -81,7 +81,7 @@ case $1 in
     fi                                                           
 
     # Start Docker daemon
-    exec docker daemon \
+    exec dockerd \
         ${DOCKER_API_CORS_HEADER} \
         ${DOCKER_BRIDGE:-} \
         ${DOCKER_DEBUG} \
@@ -96,7 +96,7 @@ case $1 in
         ${DOCKER_ENABLE_USERNS:-} \
         --exec-root ${DOCKER_DATA_DIR} \
         --group vcap \
-        --graph ${DOCKER_STORE_DIR}/docker \
+        --data-root ${DOCKER_STORE_DIR}/docker \
         --host unix://${DOCKER_PID_DIR}/docker.sock \
         ${DOCKER_ICC} \
         ${DOCKER_INSECURE_REGISTRIES:-} \

--- a/packages/docker/spec
+++ b/packages/docker/spec
@@ -5,4 +5,5 @@ files:
   - docker/aufs-tools_20120411-3_amd64.deb
   - docker/autoconf-2.69.tar.gz
   - docker/bridge-utils-1.5.tar.gz
-  - docker/docker-1.12.3.tgz
+  - docker/docker-17.06.1.tgz
+


### PR DESCRIPTION
Upgrade of docker run time  from 1.12.3 to  latest stable docker version 17.06.1-ce


