### PR TITLE
Added configs used to support skipping of events to riemann in case of client errors.

### DIFF
--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -267,6 +267,9 @@ properties:
   broker.riemann.log_additional_event:
     description: "Boolean configuration to log additional event to Riemann"
     default: true
+  broker.riemann.skip_events_with_client_errors:
+    description: "Boolean configuration to skip logging events to riemann when the HTTP response from broker indicates a client error"
+    default: true
 
   broker.syslog.host:
     description: "Syslog ingestor host IP of ELK stack"

--- a/jobs/service-fabrik-broker/spec
+++ b/jobs/service-fabrik-broker/spec
@@ -267,7 +267,7 @@ properties:
   broker.riemann.log_additional_event:
     description: "Boolean configuration to log additional event to Riemann"
     default: true
-  broker.riemann.skip_events_with_client_errors:
+  broker.riemann.skip_http_status_40x:
     description: "Boolean configuration to skip logging events to riemann when the HTTP response from broker indicates a client error"
     default: true
 

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -174,6 +174,7 @@ production:
     show_errors: <%= p('broker.riemann.show_errors') %>
     prefix: <%= p('broker.riemann.prefix') %>
     log_additional_event: <%= p('broker.riemann.log_additional_event') %>
+    skip_events_with_client_errors: <%= p('broker.riemann.skip_events_with_client_errors') %>
   ###################
   # QUOTA MANAGEMENT SETTINGS #
   ###################

--- a/jobs/service-fabrik-broker/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-broker/templates/config/settings.yml.erb
@@ -174,7 +174,7 @@ production:
     show_errors: <%= p('broker.riemann.show_errors') %>
     prefix: <%= p('broker.riemann.prefix') %>
     log_additional_event: <%= p('broker.riemann.log_additional_event') %>
-    skip_events_with_client_errors: <%= p('broker.riemann.skip_events_with_client_errors') %>
+    skip_http_status_40x: <%= p('broker.riemann.skip_http_status_40x') %>
   ###################
   # QUOTA MANAGEMENT SETTINGS #
   ###################

--- a/jobs/service-fabrik-scheduler/spec
+++ b/jobs/service-fabrik-scheduler/spec
@@ -272,6 +272,9 @@ properties:
   broker.riemann.log_additional_event:
     description: "Boolean configuration to log additional event to Riemann"
     default: true
+  broker.riemann.skip_http_status_40x:
+    description: "Boolean configuration to skip logging events to riemann when the HTTP response from broker indicates a client error"
+    default: true
 
   broker.syslog.host:
     description: "Syslog ingestor host IP of ELK stack"

--- a/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
+++ b/jobs/service-fabrik-scheduler/templates/config/settings.yml.erb
@@ -176,6 +176,7 @@ production:
     show_errors: <%= p('broker.riemann.show_errors') %>
     prefix: <%= p('broker.riemann.prefix') %>
     log_additional_event: <%= p('broker.riemann.log_additional_event') %>
+    skip_http_status_40x: <%= p('broker.riemann.skip_http_status_40x') %>
   ###################
   # QUOTA MANAGEMENT SETTINGS #
   ###################


### PR DESCRIPTION
- Added a new config in broker settings.yml which would be used to decide whether or not to skip sending events to Riemann in case the incoming request to broker was not processed due to HTTP client error - https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_errors

PR on the broker - https://github.com/SAP/service-fabrik-broker/pull/101